### PR TITLE
All tests passing

### DIFF
--- a/Assignment 2/cache.vhd
+++ b/Assignment 2/cache.vhd
@@ -153,10 +153,10 @@ begin
 				-- Check if byte has been written to the main memory
 				if (m_waitrequest = '0') then
 					-- Byte was succesfully written to the main memory
-					if (c_byteoffset = 4) then
+					if (c_byteoffset = 3) then
 						-- Word has been written to the main memory
 						c_byteoffset <= 0;
-						if (c_wordoffset = 4) then
+						if (c_wordoffset = 3) then
 							-- Block has been written to the main memory
 							c_writenextbyte <= '0';
 							-- The cache will always read after writing to the main memory
@@ -165,12 +165,13 @@ begin
 							c_wordoffset <= 0;
 							mem_read <= '1';
 						else
+							mem_writedata <= cache_d(block_idx*WORDS_PER_BLOCK + (c_wordoffset+1))(31 downto 24);
 							c_writenextbyte <= '1';
 							c_wordoffset <= c_wordoffset + 1;
 						end if;
 					else
 						mem_writedata <= cache_d(block_idx*WORDS_PER_BLOCK + c_wordoffset)
-							(31 - c_byteoffset*8 downto 24 - c_byteoffset*8);
+							(31 - (c_byteoffset+1)*8 downto 24 - (c_byteoffset+1)*8);
 						c_byteoffset <= c_byteoffset + 1;
 						c_writenextbyte <= '1';
 					end if;
@@ -227,7 +228,7 @@ begin
 						mem_addr <= to_integer(shift_left(resize(unsigned(cache_t(block_idx)), ADDRESS_START + 1), TAG_END_BIT))
 							+ block_idx;
 						mem_writedata <= cache_d(block_idx*WORDS_PER_BLOCK)(31 downto 24);
-						c_byteoffset <= 1;
+						c_byteoffset <= 0;
 						c_wordoffset <= 0;
 						mem_write <= '1';
 						-- Request the new block from the main memory
@@ -271,7 +272,7 @@ begin
 						mem_addr <= to_integer(shift_left(resize(unsigned(cache_t(block_idx)), ADDRESS_START + 1), TAG_END_BIT))
 							+ block_idx;
 						mem_writedata <= cache_d(block_idx*WORDS_PER_BLOCK)(31 downto 24);
-						c_byteoffset <= 1;
+						c_byteoffset <= 0;
 						c_wordoffset <= 0;
 						mem_write <= '1';
 						-- Get the new block from the main memory

--- a/Assignment 2/cache.vhd
+++ b/Assignment 2/cache.vhd
@@ -168,12 +168,14 @@ begin
 							mem_writedata <= cache_d(block_idx*WORDS_PER_BLOCK + (c_wordoffset+1))(31 downto 24);
 							c_writenextbyte <= '1';
 							c_wordoffset <= c_wordoffset + 1;
+							mem_addr <= mem_addr + 1;
 						end if;
 					else
 						mem_writedata <= cache_d(block_idx*WORDS_PER_BLOCK + c_wordoffset)
 							(31 - (c_byteoffset+1)*8 downto 24 - (c_byteoffset+1)*8);
 						c_byteoffset <= c_byteoffset + 1;
 						c_writenextbyte <= '1';
+						mem_addr <= mem_addr + 1;
 					end if;
 					mem_write <= '0';
 				end if;

--- a/Assignment 2/cache.vhd
+++ b/Assignment 2/cache.vhd
@@ -49,7 +49,7 @@ architecture arch of cache is
 
 	--------------- TYPE DEFINITIONS ---------------
 	-- An array type for the data in the cache
-	type cache_data is array(0 to CACHE_SIZE_WORDS-1) of std_logic_vector(31 downto 0);
+	type cache_data is array(CACHE_SIZE_WORDS-1 downto 0) of std_logic_vector(31 downto 0);
 	-- An array type for the tags in the cache
 	type cache_tags is array(CACHE_SIZE_BLOCKS-1 downto 0) of std_logic_vector(TAG_SIZE-1 downto 0);
 	-- An array type for the valid(1)/invalid(0) and dirty(1)/clean(0) flags

--- a/Assignment 2/cache.vhd
+++ b/Assignment 2/cache.vhd
@@ -63,7 +63,7 @@ architecture arch of cache is
 	-- Registers for outputs to the CPU
 	signal cpu_waitreq: std_logic := '1'; -- Wait request signal being monitored by the CPU
 	signal cpu_readdata: std_logic_vector(31 downto 0); -- The data to be read by the CPU
-	signal cpu_readcomplete: std_logic := '1'; -- Read complete flag
+	signal cpu_readcomplete: std_logic := '0'; -- Read complete flag
 	-- Registers for inputs to the main memory
 	signal mem_addr: integer range 0 to ram_size-1; -- Address of target byte in memory
 	signal mem_read: std_logic := '0'; -- High when reading from main memory

--- a/Assignment 2/cache.vhd
+++ b/Assignment 2/cache.vhd
@@ -77,10 +77,6 @@ architecture arch of cache is
 	signal c_writenextbyte: std_logic := '0'; -- Set high if another byte should be written to the memory
 	signal c_rthenwc: std_logic := '0'; -- Set high if the cache should read from main memory then write to cache
 	signal c_readcomplete: std_logic := '0'; -- Read complete flag
-	-- -- Signals for storing parts of the address specified by the CPU
-	-- signal tag: std_logic_vector(TAG_SIZE-1 downto 0); -- Tag of the address specified by the CPU
-	-- signal block_idx: natural range 0 to CACHE_SIZE_BLOCKS-1; -- Block index of the address specified by the CPU
-	-- signal offset: natural range 0 to WORDS_PER_BLOCK-1; -- Offset of the address specified by the CPU
 begin
 
 	cache_proc: process (clock, reset)

--- a/Assignment 2/cache.vhd
+++ b/Assignment 2/cache.vhd
@@ -121,6 +121,8 @@ begin
 					-- Block is now valid and clean
 					cache_f(block_idx) <= "10";
 				end if;
+				-- Update the tag
+				cache_t(block_idx) <= tag;
 				cpu_waitreq <= '0';
 
 			-- Used to trigger the main memory for a new read

--- a/Assignment 2/cache.vhd
+++ b/Assignment 2/cache.vhd
@@ -223,8 +223,8 @@ begin
 					if (cache_f(block_idx)(0) = '1') then
 						-- Write back the current block to main memory
 						-- Shift the tag of the current block and add it to the block index to get the address in memory
-						mem_addr <= to_integer(shift_left(resize(unsigned(cache_t(block_idx)), ADDRESS_START + 1), TAG_END_BIT))
-							+ block_idx;
+						mem_addr <= to_integer(shift_left(resize(unsigned(cache_t(block_idx)), ADDRESS_START + 1), TAG_END_BIT)) 
+						+ to_integer(shift_left(to_unsigned(block_idx, ADDRESS_START + 1), BLOCK_ADDR_END_BIT));
 						mem_writedata <= cache_d(block_idx*WORDS_PER_BLOCK)(31 downto 24);
 						c_byteoffset <= 0;
 						c_wordoffset <= 0;
@@ -267,8 +267,8 @@ begin
 					-- Check if block is dirty
 					if (cache_f(block_idx)(0) = '1') then
 						-- Write the old cache block to the main memory
-						mem_addr <= to_integer(shift_left(resize(unsigned(cache_t(block_idx)), ADDRESS_START + 1), TAG_END_BIT))
-							+ block_idx;
+						mem_addr <= to_integer(shift_left(resize(unsigned(cache_t(block_idx)), ADDRESS_START + 1), TAG_END_BIT)) 
+						+ to_integer(shift_left(to_unsigned(block_idx, ADDRESS_START + 1), BLOCK_ADDR_END_BIT));
 						mem_writedata <= cache_d(block_idx*WORDS_PER_BLOCK)(31 downto 24);
 						c_byteoffset <= 0;
 						c_wordoffset <= 0;
@@ -299,4 +299,3 @@ begin
 	m_write <= mem_write;
 	m_writedata <= mem_writedata;
 end arch;
-

--- a/Assignment 2/cache_tb.vhd
+++ b/Assignment 2/cache_tb.vhd
@@ -189,11 +189,11 @@ begin
     report "Test 4: Read tag equal invalid";
     s_read      <= '1';
     s_addr      <= to_address(0,0,0);
-    wait until rising_edge(s_waitrequest);
+    -- wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"00010203", error_count);
-    wait until rising_edge(clk);
+    -- wait until rising_edge(clk);
     s_read      <= '0';
 
     wait until falling_edge(clk);

--- a/Assignment 2/cache_tb.vhd
+++ b/Assignment 2/cache_tb.vhd
@@ -145,175 +145,185 @@ begin
 	reset <= '0';
     WAIT FOR clk_period;
 
-    -- Test case 1: Write Tag Equal invalid clean
-    -- Tag equal because we initalize to 000000
-    report "Test 1: Write tag equal invalid";
-    s_write      <= '1';
-    s_addr       <= to_address(0,0,0);
-    s_writedata  <= x"FFFFFFFF";
-    -- We wait until 1 cc after waitrequest falls to 0
-    wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    wait until rising_edge(clk);
-    s_write      <= '0';
+    -- -- Test case 1: Write Tag Equal invalid clean
+    -- -- Tag equal because we initalize to 000000
+    -- report "Test 1: Write tag equal invalid";
+    -- s_write      <= '1';
+    -- s_addr       <= to_address(0,0,0);
+    -- s_writedata  <= x"FFFFFFFF";
+    -- -- We wait until 1 cc after waitrequest falls to 0
+    -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- wait until rising_edge(clk);
+    -- s_write      <= '0';
 
 
-    -- Test case 2: Read Tag Equal valid clean
-    -- Reads data written to in above test case, success confirms case 1 and 2 both work
-    report "Test 2: Read tag equal valid";
+    -- -- Test case 2: Read Tag Equal valid clean
+    -- -- Reads data written to in above test case, success confirms case 1 and 2 both work
+    -- report "Test 2: Read tag equal valid";
+    -- s_read      <= '1';
+    -- s_addr      <= to_address(0,0,0);
+    -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    -- assert_equal(s_readdata, x"FFFFFFFF", error_count);
+    -- wait until rising_edge(clk);
+    -- s_read      <= '0';
+
+
+    -- -- Test case 3: Write Tag NotEqual invalid clean
+    -- report "Test 3: Write tag not equal invalid";
+    -- s_write      <= '1';
+    -- -- Change tag and block
+    -- s_addr       <= to_address(1,1,0);
+    -- s_writedata  <= x"FFFFFFFF";
+    -- -- We wait until 1 cc after waitrequest falls to 0
+    -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- wait until rising_edge(clk);
+    -- s_write      <= '0';
+
+
+    -- Test case 4: Read Tag Equal valid clean
+    -- Reads data written to in above test case, success confirms case 3 and 4 both work
+    report "Test 4: Read tag equal invalid";
     s_read      <= '1';
     s_addr      <= to_address(0,0,0);
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    assert_equal(s_readdata, x"FFFFFFFF", error_count);
+    assert_equal(s_readdata, x"00010203", error_count);
     wait until rising_edge(clk);
     s_read      <= '0';
 
-
-    -- Test case 3: Write Tag NotEqual invalid clean
-    report "Test 3: Write tag not equal invalid";
-    s_write      <= '1';
-    -- Change tag and block
-    s_addr       <= to_address(1,1,0);
-    s_writedata  <= x"FFFFFFFF";
-    -- We wait until 1 cc after waitrequest falls to 0
-    wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    wait until rising_edge(clk);
-    s_write      <= '0';
-
-
-    -- Test case 4: Read Tag Equal valid clean
-    -- Reads data written to in above test case, success confirms case 3 and 4 both work
-    report "Test 4: Read tag equal valid";
+    report "Test 4a: Read tag equal valid";
     s_read      <= '1';
-    s_addr      <= to_address(1,1,0);
+    s_addr      <= to_address(0,0,2);
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    assert_equal(s_readdata, x"FFFFFFFF", error_count);
+    assert_equal(s_readdata, x"08090A0B", error_count);
     wait until rising_edge(clk);
     s_read      <= '0';
 
 
-    -- Test case 5: Write Tag Equal valid clean
-    -- Overwrites the data from test 3, should become dirty afterwards
-    report "Test 5: Write tag equal valid clean to dirty";
-    s_write      <= '1';
-    s_addr       <= to_address(1,1,0);
-    s_writedata  <= x"FAFAFAFA";
-    -- We wait until 1 cc after waitrequest falls to 0
-    wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    wait until rising_edge(clk);
-    s_write      <= '0';
+    -- -- Test case 5: Write Tag Equal valid clean
+    -- -- Overwrites the data from test 3, should become dirty afterwards
+    -- report "Test 5: Write tag equal valid clean to dirty";
+    -- s_write      <= '1';
+    -- s_addr       <= to_address(1,1,0);
+    -- s_writedata  <= x"FAFAFAFA";
+    -- -- We wait until 1 cc after waitrequest falls to 0
+    -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- wait until rising_edge(clk);
+    -- s_write      <= '0';
 
 
-    -- Test case 6: Read Tag Equal valid dirty
-    report "Test 6: Read tag equal valid";
-    s_read      <= '1';
-    s_addr      <= to_address(1,1,0);
-    wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    assert_equal(s_readdata, x"FAFAFAFA", error_count);
-    wait until rising_edge(clk);
-    s_read      <= '0';
+    -- -- Test case 6: Read Tag Equal valid dirty
+    -- report "Test 6: Read tag equal valid";
+    -- s_read      <= '1';
+    -- s_addr      <= to_address(1,1,0);
+    -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    -- assert_equal(s_readdata, x"FAFAFAFA", error_count);
+    -- wait until rising_edge(clk);
+    -- s_read      <= '0';
 
 
-    -- Test case 7: Write Tag Equal valid dirty
-    -- Overwrites the data from test 5, should stay dirty
-    report "Test 7: Write tag equal valid dirty to dirty";
-    s_write      <= '1';
-    s_addr       <= to_address(1,1,0);
-    s_writedata  <= x"12121212";
-    -- We wait until 1 cc after waitrequest falls to 0
-    wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    wait until rising_edge(clk);
-    s_write      <= '0';
+    -- -- Test case 7: Write Tag Equal valid dirty
+    -- -- Overwrites the data from test 5, should stay dirty
+    -- report "Test 7: Write tag equal valid dirty to dirty";
+    -- s_write      <= '1';
+    -- s_addr       <= to_address(1,1,0);
+    -- s_writedata  <= x"12121212";
+    -- -- We wait until 1 cc after waitrequest falls to 0
+    -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- wait until rising_edge(clk);
+    -- s_write      <= '0';
 
-    -- Test case 8: Read Tag Equal valid dirty
-    report "Test 8: Read tag equal valid";
-    s_read      <= '1';
-    s_addr      <= to_address(1,1,0);
-    wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    assert_equal(s_readdata, x"12121212", error_count);
-    wait until rising_edge(clk);
-    s_read      <= '0';
+    -- -- Test case 8: Read Tag Equal valid dirty
+    -- report "Test 8: Read tag equal valid";
+    -- s_read      <= '1';
+    -- s_addr      <= to_address(1,1,0);
+    -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    -- assert_equal(s_readdata, x"12121212", error_count);
+    -- wait until rising_edge(clk);
+    -- s_read      <= '0';
 
 
-    -- Test case 9: Write Tag Not Equal valid dirty
-    -- Overwrites the data from test 7, should stay dirty
-    report "Test 9: Write tag not equal valid dirty to dirty";
-    s_write      <= '1';
-    s_addr       <= to_address(2,1,0);
-    s_writedata  <= x"ACACACAC";
-    -- We wait until 1 cc after waitrequest falls to 0
-    wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    wait until rising_edge(clk);
-    s_write      <= '0';
+    -- -- Test case 9: Write Tag Not Equal valid dirty
+    -- -- Overwrites the data from test 7, should stay dirty
+    -- report "Test 9: Write tag not equal valid dirty to dirty";
+    -- s_write      <= '1';
+    -- s_addr       <= to_address(2,1,0);
+    -- s_writedata  <= x"ACACACAC";
+    -- -- We wait until 1 cc after waitrequest falls to 0
+    -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- wait until rising_edge(clk);
+    -- s_write      <= '0';
 
-    -- Test case 10: Read Tag Equal valid dirty
-    report "Test 10: Read tag equal valid dirty";
-    s_read      <= '1';
-    s_addr      <= to_address(2,1,0);
-    wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    assert_equal(s_readdata, x"ACACACAC", error_count);
-    wait until rising_edge(clk);
-    s_read      <= '0';
+    -- -- Test case 10: Read Tag Equal valid dirty
+    -- report "Test 10: Read tag equal valid dirty";
+    -- s_read      <= '1';
+    -- s_addr      <= to_address(2,1,0);
+    -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    -- assert_equal(s_readdata, x"ACACACAC", error_count);
+    -- wait until rising_edge(clk);
+    -- s_read      <= '0';
 
-    -- Test case 11: Read Tag Not Equal valid dirty
-    report "Test 11: Read tag not equal valid dirty";
-    -- Data not in cache. Write data in cache to main memory, load data from main memory, mark as clean
-    s_read      <= '1';
-    s_addr      <= to_address(1,1,0);
-    wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    assert_equal(s_readdata, x"12121212", error_count);
-    wait until rising_edge(clk);
-    s_read      <= '0';
+    -- -- Test case 11: Read Tag Not Equal valid dirty
+    -- report "Test 11: Read tag not equal valid dirty";
+    -- -- Data not in cache. Write data in cache to main memory, load data from main memory, mark as clean
+    -- s_read      <= '1';
+    -- s_addr      <= to_address(1,1,0);
+    -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    -- assert_equal(s_readdata, x"12121212", error_count);
+    -- wait until rising_edge(clk);
+    -- s_read      <= '0';
 
-    -- Test case 12: Read Tag Not Equal valid clean
-    report "Test 12: Read tag not equal valid clean";
-    -- Data not in cache. Data in cache is clean so no write. Load data from main memory, mark as clean
-    s_read      <= '1';
-    s_addr      <= to_address(2,1,0);
-    wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    assert_equal(s_readdata, x"ACACACAC", error_count);
-    wait until rising_edge(clk);
-    s_read      <= '0';
+    -- -- Test case 12: Read Tag Not Equal valid clean
+    -- report "Test 12: Read tag not equal valid clean";
+    -- -- Data not in cache. Data in cache is clean so no write. Load data from main memory, mark as clean
+    -- s_read      <= '1';
+    -- s_addr      <= to_address(2,1,0);
+    -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    -- assert_equal(s_readdata, x"ACACACAC", error_count);
+    -- wait until rising_edge(clk);
+    -- s_read      <= '0';
     
-    -- Test case 13: Write Tag Not Equal valid clean
-    -- Load block from main memory. Data clean so no write to memory. Set to dirty
-    report "Test 13: Write tag not equal valid clean to dirty";
-    s_write      <= '1';
-    s_addr       <= to_address(3,1,0);
-    s_writedata  <= x"00001111";
-    -- We wait until 1 cc after waitrequest falls to 0
-    wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    wait until rising_edge(clk);
-    s_write      <= '0';
+    -- -- Test case 13: Write Tag Not Equal valid clean
+    -- -- Load block from main memory. Data clean so no write to memory. Set to dirty
+    -- report "Test 13: Write tag not equal valid clean to dirty";
+    -- s_write      <= '1';
+    -- s_addr       <= to_address(3,1,0);
+    -- s_writedata  <= x"00001111";
+    -- -- We wait until 1 cc after waitrequest falls to 0
+    -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- wait until rising_edge(clk);
+    -- s_write      <= '0';
 
-    -- Now read data from cache to confirm validity
-    s_read      <= '1';
-    s_addr      <= to_address(3,1,0);
-    wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    assert_equal(s_readdata, x"00001111", error_count);
-    wait until rising_edge(clk);
-    s_read      <= '0';
+    -- -- Now read data from cache to confirm validity
+    -- s_read      <= '1';
+    -- s_addr      <= to_address(3,1,0);
+    -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    -- assert_equal(s_readdata, x"00001111", error_count);
+    -- wait until rising_edge(clk);
+    -- s_read      <= '0';
 
     Report "Resetting cache";
     -- Reset cache

--- a/Assignment 2/cache_tb.vhd
+++ b/Assignment 2/cache_tb.vhd
@@ -145,214 +145,175 @@ begin
 	reset <= '0';
     WAIT FOR clk_period;
 
-    -- -- Test case 1: Write Tag Equal invalid clean
-    -- -- Tag equal because we initalize to 000000
-    -- report "Test 1: Write tag equal invalid";
-    -- s_write      <= '1';
-    -- s_addr       <= to_address(0,0,0);
-    -- s_writedata  <= x"FFFFFFFF";
-    -- -- We wait until 1 cc after waitrequest falls to 0
-    -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
-    -- wait until rising_edge(clk);
-    -- s_write      <= '0';
+    -- Test case 1: Write Tag Equal invalid clean
+    -- Tag equal because we initalize to 000000
+    report "Test 1: Write tag equal invalid";
+    s_write      <= '1';
+    s_addr       <= to_address(0,0,0);
+    s_writedata  <= x"FFFFFFFF";
+    -- We wait until 1 cc after waitrequest falls to 0
+    wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    wait until rising_edge(clk);
+    s_write      <= '0';
 
 
-    -- -- Test case 2: Read Tag Equal valid clean
-    -- -- Reads data written to in above test case, success confirms case 1 and 2 both work
-    -- report "Test 2: Read tag equal valid";
-    -- s_read      <= '1';
-    -- s_addr      <= to_address(0,0,0);
-    -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
-    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    -- assert_equal(s_readdata, x"FFFFFFFF", error_count);
-    -- wait until rising_edge(clk);
-    -- s_read      <= '0';
+    -- Test case 2: Read Tag Equal valid clean
+    -- Reads data written to in above test case, success confirms case 1 and 2 both work
+    report "Test 2: Read tag equal valid";
+    s_read      <= '1';
+    s_addr      <= to_address(0,0,0);
+    wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    assert_equal(s_readdata, x"FFFFFFFF", error_count);
+    wait until rising_edge(clk);
+    s_read      <= '0';
 
 
     -- Test case 3: Write Tag NotEqual invalid clean
     report "Test 3: Write tag not equal invalid";
     s_write      <= '1';
     -- Change tag and block
-    s_addr       <= to_address(0,0,0);
+    s_addr       <= to_address(1,1,0);
     s_writedata  <= x"FFFFFFFF";
     -- We wait until 1 cc after waitrequest falls to 0
-    -- wait until rising_edge(s_waitrequest);
+    wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
-    -- wait until rising_edge(clk);
+    wait until rising_edge(clk);
     s_write      <= '0';
 
-    wait until falling_edge(clk);
-
-    -- Test case 3a: Write Tag NotEqual valid clean
-    report "Test 3a: Write tag not equal valid";
-    s_write      <= '1';
-    -- Change tag and block
-    s_addr       <= to_address(1,0,0);
-    s_writedata  <= x"AAAAAAAA";
-    -- We wait until 1 cc after waitrequest falls to 0
-    -- wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    -- wait until rising_edge(clk);
-    s_write      <= '0';
-
-    wait until falling_edge(clk);
 
     -- Test case 4: Read Tag Equal valid clean
     -- Reads data written to in above test case, success confirms case 3 and 4 both work
-    -- report "Test 4: Read tag equal invalid";
-    -- s_read      <= '1';
-    -- s_addr      <= to_address(0,0,0);
-    -- -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
-    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    -- assert_equal(s_readdata, x"00010203", error_count);
-    -- -- wait until rising_edge(clk);
-    -- s_read      <= '0';
-
-    
-
-    report "Test 4a: Read tag equal valid";
+    report "Test 4: Read tag equal valid";
     s_read      <= '1';
-    s_addr      <= to_address(1,0,0);
-    -- wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    assert_equal(s_readdata, x"AAAAAAAA", error_count);
-    -- wait until rising_edge(clk);
-    s_read      <= '0';
-    wait until falling_edge(clk);
-
-    report "Test 4b: Read tag not equal valid";
-    s_read      <= '1';
-    s_addr      <= to_address(0,0,0);
-    -- wait until rising_edge(s_waitrequest);
+    s_addr      <= to_address(1,1,0);
+    wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"FFFFFFFF", error_count);
-    -- wait until rising_edge(clk);
+    wait until rising_edge(clk);
     s_read      <= '0';
-    wait until falling_edge(clk);
 
 
-    -- -- Test case 5: Write Tag Equal valid clean
-    -- -- Overwrites the data from test 3, should become dirty afterwards
-    -- report "Test 5: Write tag equal valid clean to dirty";
-    -- s_write      <= '1';
-    -- s_addr       <= to_address(1,1,0);
-    -- s_writedata  <= x"FAFAFAFA";
-    -- -- We wait until 1 cc after waitrequest falls to 0
-    -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
-    -- wait until rising_edge(clk);
-    -- s_write      <= '0';
+    -- Test case 5: Write Tag Equal valid clean
+    -- Overwrites the data from test 3, should become dirty afterwards
+    report "Test 5: Write tag equal valid clean to dirty";
+    s_write      <= '1';
+    s_addr       <= to_address(1,1,0);
+    s_writedata  <= x"FAFAFAFA";
+    -- We wait until 1 cc after waitrequest falls to 0
+    wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    wait until rising_edge(clk);
+    s_write      <= '0';
 
 
-    -- -- Test case 6: Read Tag Equal valid dirty
-    -- report "Test 6: Read tag equal valid";
-    -- s_read      <= '1';
-    -- s_addr      <= to_address(1,1,0);
-    -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
-    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    -- assert_equal(s_readdata, x"FAFAFAFA", error_count);
-    -- wait until rising_edge(clk);
-    -- s_read      <= '0';
+    -- Test case 6: Read Tag Equal valid dirty
+    report "Test 6: Read tag equal valid";
+    s_read      <= '1';
+    s_addr      <= to_address(1,1,0);
+    wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    assert_equal(s_readdata, x"FAFAFAFA", error_count);
+    wait until rising_edge(clk);
+    s_read      <= '0';
 
 
-    -- -- Test case 7: Write Tag Equal valid dirty
-    -- -- Overwrites the data from test 5, should stay dirty
-    -- report "Test 7: Write tag equal valid dirty to dirty";
-    -- s_write      <= '1';
-    -- s_addr       <= to_address(1,1,0);
-    -- s_writedata  <= x"12121212";
-    -- -- We wait until 1 cc after waitrequest falls to 0
-    -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
-    -- wait until rising_edge(clk);
-    -- s_write      <= '0';
+    -- Test case 7: Write Tag Equal valid dirty
+    -- Overwrites the data from test 5, should stay dirty
+    report "Test 7: Write tag equal valid dirty to dirty";
+    s_write      <= '1';
+    s_addr       <= to_address(1,1,0);
+    s_writedata  <= x"12121212";
+    -- We wait until 1 cc after waitrequest falls to 0
+    wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    wait until rising_edge(clk);
+    s_write      <= '0';
 
-    -- -- Test case 8: Read Tag Equal valid dirty
-    -- report "Test 8: Read tag equal valid";
-    -- s_read      <= '1';
-    -- s_addr      <= to_address(1,1,0);
-    -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
-    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    -- assert_equal(s_readdata, x"12121212", error_count);
-    -- wait until rising_edge(clk);
-    -- s_read      <= '0';
+    -- Test case 8: Read Tag Equal valid dirty
+    report "Test 8: Read tag equal valid";
+    s_read      <= '1';
+    s_addr      <= to_address(1,1,0);
+    wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    assert_equal(s_readdata, x"12121212", error_count);
+    wait until rising_edge(clk);
+    s_read      <= '0';
 
 
-    -- -- Test case 9: Write Tag Not Equal valid dirty
-    -- -- Overwrites the data from test 7, should stay dirty
-    -- report "Test 9: Write tag not equal valid dirty to dirty";
-    -- s_write      <= '1';
-    -- s_addr       <= to_address(2,1,0);
-    -- s_writedata  <= x"ACACACAC";
-    -- -- We wait until 1 cc after waitrequest falls to 0
-    -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
-    -- wait until rising_edge(clk);
-    -- s_write      <= '0';
+    -- Test case 9: Write Tag Not Equal valid dirty
+    -- Overwrites the data from test 7, should stay dirty
+    report "Test 9: Write tag not equal valid dirty to dirty";
+    s_write      <= '1';
+    s_addr       <= to_address(2,1,0);
+    s_writedata  <= x"ACACACAC";
+    -- We wait until 1 cc after waitrequest falls to 0
+    wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    wait until rising_edge(clk);
+    s_write      <= '0';
 
-    -- -- Test case 10: Read Tag Equal valid dirty
-    -- report "Test 10: Read tag equal valid dirty";
-    -- s_read      <= '1';
-    -- s_addr      <= to_address(2,1,0);
-    -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
-    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    -- assert_equal(s_readdata, x"ACACACAC", error_count);
-    -- wait until rising_edge(clk);
-    -- s_read      <= '0';
+    -- Test case 10: Read Tag Equal valid dirty
+    report "Test 10: Read tag equal valid dirty";
+    s_read      <= '1';
+    s_addr      <= to_address(2,1,0);
+    wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    assert_equal(s_readdata, x"ACACACAC", error_count);
+    wait until rising_edge(clk);
+    s_read      <= '0';
 
-    -- -- Test case 11: Read Tag Not Equal valid dirty
-    -- report "Test 11: Read tag not equal valid dirty";
-    -- -- Data not in cache. Write data in cache to main memory, load data from main memory, mark as clean
-    -- s_read      <= '1';
-    -- s_addr      <= to_address(1,1,0);
-    -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
-    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    -- assert_equal(s_readdata, x"12121212", error_count);
-    -- wait until rising_edge(clk);
-    -- s_read      <= '0';
+    -- Test case 11: Read Tag Not Equal valid dirty
+    report "Test 11: Read tag not equal valid dirty";
+    -- Data not in cache. Write data in cache to main memory, load data from main memory, mark as clean
+    s_read      <= '1';
+    s_addr      <= to_address(1,1,0);
+    wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    assert_equal(s_readdata, x"12121212", error_count);
+    wait until rising_edge(clk);
+    s_read      <= '0';
 
-    -- -- Test case 12: Read Tag Not Equal valid clean
-    -- report "Test 12: Read tag not equal valid clean";
-    -- -- Data not in cache. Data in cache is clean so no write. Load data from main memory, mark as clean
-    -- s_read      <= '1';
-    -- s_addr      <= to_address(2,1,0);
-    -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
-    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    -- assert_equal(s_readdata, x"ACACACAC", error_count);
-    -- wait until rising_edge(clk);
-    -- s_read      <= '0';
+    -- Test case 12: Read Tag Not Equal valid clean
+    report "Test 12: Read tag not equal valid clean";
+    -- Data not in cache. Data in cache is clean so no write. Load data from main memory, mark as clean
+    s_read      <= '1';
+    s_addr      <= to_address(2,1,0);
+    wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    assert_equal(s_readdata, x"ACACACAC", error_count);
+    wait until rising_edge(clk);
+    s_read      <= '0';
     
-    -- -- Test case 13: Write Tag Not Equal valid clean
-    -- -- Load block from main memory. Data clean so no write to memory. Set to dirty
-    -- report "Test 13: Write tag not equal valid clean to dirty";
-    -- s_write      <= '1';
-    -- s_addr       <= to_address(3,1,0);
-    -- s_writedata  <= x"00001111";
-    -- -- We wait until 1 cc after waitrequest falls to 0
-    -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
-    -- wait until rising_edge(clk);
-    -- s_write      <= '0';
+    -- Test case 13: Write Tag Not Equal valid clean
+    -- Load block from main memory. Data clean so no write to memory. Set to dirty
+    report "Test 13: Write tag not equal valid clean to dirty";
+    s_write      <= '1';
+    s_addr       <= to_address(3,1,0);
+    s_writedata  <= x"00001111";
+    -- We wait until 1 cc after waitrequest falls to 0
+    wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    wait until rising_edge(clk);
+    s_write      <= '0';
 
-    -- -- Now read data from cache to confirm validity
-    -- s_read      <= '1';
-    -- s_addr      <= to_address(3,1,0);
-    -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
-    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    -- assert_equal(s_readdata, x"00001111", error_count);
-    -- wait until rising_edge(clk);
-    -- s_read      <= '0';
+    -- Now read data from cache to confirm validity
+    s_read      <= '1';
+    s_addr      <= to_address(3,1,0);
+    wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    assert_equal(s_readdata, x"00001111", error_count);
+    wait until rising_edge(clk);
+    s_read      <= '0';
 
     Report "Resetting cache";
     -- Reset cache

--- a/Assignment 2/cache_tb.vhd
+++ b/Assignment 2/cache_tb.vhd
@@ -9,8 +9,7 @@ architecture behavior of cache_tb is
 
 component cache is
 generic(
-    ram_size : INTEGER := 32768;
-);
+    ram_size : INTEGER := 32768);
 port(
     clock : in std_logic;
     reset : in std_logic;
@@ -148,172 +147,172 @@ begin
 
     -- Test case 1: Write Tag Equal invalid clean
     -- Tag equal because we initalize to 000000
-    report "Test 1: Write tag equal invalid"
+    report "Test 1: Write tag equal invalid";
     s_write      <= '1';
-    s_addr       <= to_address(0,0,0)
+    s_addr       <= to_address(0,0,0);
     s_writedata  <= x"FFFFFFFF";
     -- We wait until 1 cc after waitrequest falls to 0
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_write      <= '0';
 
 
     -- Test case 2: Read Tag Equal valid clean
     -- Reads data written to in above test case, success confirms case 1 and 2 both work
-    report "Test 2: Read tag equal valid"
+    report "Test 2: Read tag equal valid";
     s_read      <= '1';
-    s_addr      <= to_address(0,0,0)
+    s_addr      <= to_address(0,0,0);
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"FFFFFFFF", error_count);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_read      <= '0';
 
 
     -- Test case 3: Write Tag NotEqual invalid clean
-    report "Test 3: Write tag not equal invalid"
+    report "Test 3: Write tag not equal invalid";
     s_write      <= '1';
     -- Change tag and block
-    s_addr       <= to_address(1,1,0)
+    s_addr       <= to_address(1,1,0);
     s_writedata  <= x"FFFFFFFF";
     -- We wait until 1 cc after waitrequest falls to 0
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_write      <= '0';
 
 
     -- Test case 4: Read Tag Equal valid clean
     -- Reads data written to in above test case, success confirms case 3 and 4 both work
-    report "Test 4: Read tag equal valid"
+    report "Test 4: Read tag equal valid";
     s_read      <= '1';
-    s_addr      <= to_address(1,1,0)
+    s_addr      <= to_address(1,1,0);
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"FFFFFFFF", error_count);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_read      <= '0';
 
 
     -- Test case 5: Write Tag Equal valid clean
     -- Overwrites the data from test 3, should become dirty afterwards
-    report "Test 5: Write tag equal valid clean to dirty"
+    report "Test 5: Write tag equal valid clean to dirty";
     s_write      <= '1';
-    s_addr       <= to_address(1,1,0)
+    s_addr       <= to_address(1,1,0);
     s_writedata  <= x"FAFAFAFA";
     -- We wait until 1 cc after waitrequest falls to 0
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_write      <= '0';
 
 
     -- Test case 6: Read Tag Equal valid dirty
-    report "Test 6: Read tag equal valid"
+    report "Test 6: Read tag equal valid";
     s_read      <= '1';
-    s_addr      <= to_address(1,1,0)
+    s_addr      <= to_address(1,1,0);
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"FAFAFAFA", error_count);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_read      <= '0';
 
 
     -- Test case 7: Write Tag Equal valid dirty
     -- Overwrites the data from test 5, should stay dirty
-    report "Test 7: Write tag equal valid dirty to dirty"
+    report "Test 7: Write tag equal valid dirty to dirty";
     s_write      <= '1';
-    s_addr       <= to_address(1,1,0)
+    s_addr       <= to_address(1,1,0);
     s_writedata  <= x"12121212";
     -- We wait until 1 cc after waitrequest falls to 0
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_write      <= '0';
 
     -- Test case 8: Read Tag Equal valid dirty
-    report "Test 8: Read tag equal valid"
+    report "Test 8: Read tag equal valid";
     s_read      <= '1';
-    s_addr      <= to_address(1,1,0)
+    s_addr      <= to_address(1,1,0);
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"12121212", error_count);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_read      <= '0';
 
 
     -- Test case 9: Write Tag Not Equal valid dirty
     -- Overwrites the data from test 7, should stay dirty
-    report "Test 9: Write tag not equal valid dirty to dirty"
+    report "Test 9: Write tag not equal valid dirty to dirty";
     s_write      <= '1';
-    s_addr       <= to_address(2,1,0)
+    s_addr       <= to_address(2,1,0);
     s_writedata  <= x"ACACACAC";
     -- We wait until 1 cc after waitrequest falls to 0
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_write      <= '0';
 
     -- Test case 10: Read Tag Equal valid dirty
-    report "Test 10: Read tag equal valid dirty"
+    report "Test 10: Read tag equal valid dirty";
     s_read      <= '1';
-    s_addr      <= to_address(2,1,0)
+    s_addr      <= to_address(2,1,0);
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"ACACACAC", error_count);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_read      <= '0';
 
     -- Test case 11: Read Tag Not Equal valid dirty
-    report "Test 11: Read tag not equal valid dirty"
+    report "Test 11: Read tag not equal valid dirty";
     -- Data not in cache. Write data in cache to main memory, load data from main memory, mark as clean
     s_read      <= '1';
-    s_addr      <= to_address(1,1,0)
+    s_addr      <= to_address(1,1,0);
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"12121212", error_count);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_read      <= '0';
 
     -- Test case 12: Read Tag Not Equal valid clean
-    report "Test 12: Read tag not equal valid clean"
+    report "Test 12: Read tag not equal valid clean";
     -- Data not in cache. Data in cache is clean so no write. Load data from main memory, mark as clean
     s_read      <= '1';
-    s_addr      <= to_address(2,1,0)
+    s_addr      <= to_address(2,1,0);
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"ACACACAC", error_count);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_read      <= '0';
     
     -- Test case 13: Write Tag Not Equal valid clean
     -- Load block from main memory. Data clean so no write to memory. Set to dirty
-    report "Test 13: Write tag not equal valid clean to dirty"
+    report "Test 13: Write tag not equal valid clean to dirty";
     s_write      <= '1';
-    s_addr       <= to_address(3,1,0)
+    s_addr       <= to_address(3,1,0);
     s_writedata  <= x"00001111";
     -- We wait until 1 cc after waitrequest falls to 0
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_write      <= '0';
 
     -- Now read data from cache to confirm validity
     s_read      <= '1';
-    s_addr      <= to_address(3,1,0)
+    s_addr      <= to_address(3,1,0);
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"00001111", error_count);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_read      <= '0';
 
     Report "Resetting cache";
@@ -326,25 +325,25 @@ begin
     WAIT FOR clk_period;
 
     -- Test case 14: Read Tag Equal invalid clean
-    report "Test 14: Read Tag Equal invalid clean"
+    report "Test 14: Read Tag Equal invalid clean";
     s_read      <= '1';
-    s_addr      <= to_address(0,0,0)
+    s_addr      <= to_address(0,0,0);
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"FFFFFFFF", error_count);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_read      <= '0';
 
     -- Test case 15: Read Tag Not Equal invalid clean
-    report "Test 15: Read Tag Not Equal invalid clean"
+    report "Test 15: Read Tag Not Equal invalid clean";
     s_read      <= '1';
-    s_addr      <= to_address(1,1,0)
+    s_addr      <= to_address(1,1,0);
     wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"12121212", error_count);
-    wait until rising_edge(clock);
+    wait until rising_edge(clk);
     s_read      <= '0';
 
 end process;

--- a/Assignment 2/cache_tb.vhd
+++ b/Assignment 2/cache_tb.vhd
@@ -175,7 +175,7 @@ begin
     report "Test 3: Write tag not equal invalid";
     s_write      <= '1';
     -- Change tag and block
-    s_addr       <= to_address(1,1,1);
+    s_addr       <= to_address(0,0,0);
     s_writedata  <= x"FFFFFFFF";
     -- We wait until 1 cc after waitrequest falls to 0
     -- wait until rising_edge(s_waitrequest);
@@ -183,6 +183,21 @@ begin
     -- wait until rising_edge(clk);
     s_write      <= '0';
 
+    wait until falling_edge(clk);
+
+    -- Test case 3a: Write Tag NotEqual valid clean
+    report "Test 3a: Write tag not equal valid";
+    s_write      <= '1';
+    -- Change tag and block
+    s_addr       <= to_address(1,0,0);
+    s_writedata  <= x"AAAAAAAA";
+    -- We wait until 1 cc after waitrequest falls to 0
+    -- wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    -- wait until rising_edge(clk);
+    s_write      <= '0';
+
+    wait until falling_edge(clk);
 
     -- Test case 4: Read Tag Equal valid clean
     -- Reads data written to in above test case, success confirms case 3 and 4 both work
@@ -196,18 +211,29 @@ begin
     -- -- wait until rising_edge(clk);
     -- s_read      <= '0';
 
-    wait until falling_edge(clk);
+    
 
     report "Test 4a: Read tag equal valid";
     s_read      <= '1';
-    s_addr      <= to_address(1,1,1);
+    s_addr      <= to_address(1,0,0);
+    -- wait until rising_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
+    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    assert_equal(s_readdata, x"AAAAAAAA", error_count);
+    -- wait until rising_edge(clk);
+    s_read      <= '0';
+    wait until falling_edge(clk);
+
+    report "Test 4b: Read tag not equal valid";
+    s_read      <= '1';
+    s_addr      <= to_address(0,0,0);
     -- wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"FFFFFFFF", error_count);
     -- wait until rising_edge(clk);
     s_read      <= '0';
-    wait until rising_edge(clk);
+    wait until falling_edge(clk);
 
 
     -- -- Test case 5: Write Tag Equal valid clean

--- a/Assignment 2/cache_tb.vhd
+++ b/Assignment 2/cache_tb.vhd
@@ -201,12 +201,13 @@ begin
     report "Test 4a: Read tag equal valid";
     s_read      <= '1';
     s_addr      <= to_address(0,0,2);
-    wait until rising_edge(s_waitrequest);
+    -- wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
     assert_equal(s_readdata, x"08090A0B", error_count);
-    wait until rising_edge(clk);
+    -- wait until rising_edge(clk);
     s_read      <= '0';
+    wait until rising_edge(clk);
 
 
     -- -- Test case 5: Write Tag Equal valid clean

--- a/Assignment 2/cache_tb.vhd
+++ b/Assignment 2/cache_tb.vhd
@@ -196,6 +196,8 @@ begin
     wait until rising_edge(clk);
     s_read      <= '0';
 
+    wait until falling_edge(clk);
+
     report "Test 4a: Read tag equal valid";
     s_read      <= '1';
     s_addr      <= to_address(0,0,2);

--- a/Assignment 2/cache_tb.vhd
+++ b/Assignment 2/cache_tb.vhd
@@ -171,40 +171,40 @@ begin
     -- s_read      <= '0';
 
 
-    -- -- Test case 3: Write Tag NotEqual invalid clean
-    -- report "Test 3: Write tag not equal invalid";
-    -- s_write      <= '1';
-    -- -- Change tag and block
-    -- s_addr       <= to_address(1,1,0);
-    -- s_writedata  <= x"FFFFFFFF";
-    -- -- We wait until 1 cc after waitrequest falls to 0
+    -- Test case 3: Write Tag NotEqual invalid clean
+    report "Test 3: Write tag not equal invalid";
+    s_write      <= '1';
+    -- Change tag and block
+    s_addr       <= to_address(1,1,1);
+    s_writedata  <= x"FFFFFFFF";
+    -- We wait until 1 cc after waitrequest falls to 0
     -- wait until rising_edge(s_waitrequest);
-    -- wait until falling_edge(s_waitrequest);
+    wait until falling_edge(s_waitrequest);
     -- wait until rising_edge(clk);
-    -- s_write      <= '0';
+    s_write      <= '0';
 
 
     -- Test case 4: Read Tag Equal valid clean
     -- Reads data written to in above test case, success confirms case 3 and 4 both work
-    report "Test 4: Read tag equal invalid";
-    s_read      <= '1';
-    s_addr      <= to_address(0,0,0);
-    -- wait until rising_edge(s_waitrequest);
-    wait until falling_edge(s_waitrequest);
-    -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    assert_equal(s_readdata, x"00010203", error_count);
-    -- wait until rising_edge(clk);
-    s_read      <= '0';
+    -- report "Test 4: Read tag equal invalid";
+    -- s_read      <= '1';
+    -- s_addr      <= to_address(0,0,0);
+    -- -- wait until rising_edge(s_waitrequest);
+    -- wait until falling_edge(s_waitrequest);
+    -- -- Data is exposed for 1 cc at the falling edge of s_waitrequest
+    -- assert_equal(s_readdata, x"00010203", error_count);
+    -- -- wait until rising_edge(clk);
+    -- s_read      <= '0';
 
     wait until falling_edge(clk);
 
     report "Test 4a: Read tag equal valid";
     s_read      <= '1';
-    s_addr      <= to_address(0,0,2);
+    s_addr      <= to_address(1,1,1);
     -- wait until rising_edge(s_waitrequest);
     wait until falling_edge(s_waitrequest);
     -- Data is exposed for 1 cc at the falling edge of s_waitrequest
-    assert_equal(s_readdata, x"08090A0B", error_count);
+    assert_equal(s_readdata, x"FFFFFFFF", error_count);
     -- wait until rising_edge(clk);
     s_read      <= '0';
     wait until rising_edge(clk);


### PR DESCRIPTION
All 12 major tests pass for cache.vhd. Overhauled cache_tb.vhd to be cleaner and more efficient. Tests 2 and 11 are sensitive to changing the offset (update the values based on preloaded memory to fix).